### PR TITLE
Running `npx @next/codemod@canary next-async-request-api`

### DIFF
--- a/examples/sync-org-with-url/src/app/orgs/[slug]/page.tsx
+++ b/examples/sync-org-with-url/src/app/orgs/[slug]/page.tsx
@@ -1,9 +1,12 @@
 import { auth } from '@clerk/nextjs/server';
 import {OrganizationList} from "@clerk/nextjs";
 
-export default async function Home({params}:{
-  params: { slug: string }
-}) {
+export default async function Home(
+  props:{
+    params: Promise<{ slug: string }>
+  }
+) {
+  const params = await props.params;
   const authObject = await auth();
   const orgSlug = authObject.orgSlug
 


### PR DESCRIPTION
One more small issue - `params` is now async.

Running `npx @next/codemod@canary next-async-request-api` (per https://nextjs.org/docs/messages/sync-dynamic-apis) produced this fix.