### PR TITLE
fix: Escape HTML for email addresses

### DIFF
--- a/examples/disable-personal-account-javascript/src/main.js
+++ b/examples/disable-personal-account-javascript/src/main.js
@@ -70,12 +70,21 @@ function showDashboard() {
   updateOrgInfo();
 }
 
+function escapeHtml(str) {
+  return str
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+};
+
 function updateUserInfo() {
   const user = clerk.user;
   if (user) {
     userInfoEl.innerHTML = `
       <h2>User Information</h2>
-      <p><strong>Email:</strong> ${user.primaryEmailAddress.emailAddress}</p>
+      <p><strong>Email:</strong> ${escapeHtml(user.primaryEmailAddress.emailAddress)}</p>
       <p><strong>User ID:</strong> ${user.id}</p>
     `;
   }


### PR DESCRIPTION
I know this is only an example repo, but I came here from a semgrep finding :)

Normal email addresses don't need escaping, but technically `"<img src=x onerror=alert(document.domain)"@example.com` is a valid email address and causes XSS. This is only an example project here but let's make sure users using this example don't assume that emails are safe to be used directly in HTML.

The frontend prevents such an email, but I could set it directly in my clerk dashboard.

| Before | After |
| - | - |
| ![](https://github.com/user-attachments/assets/aa4965ce-1e2c-48da-bb8f-3a68e7366a99) | ![](https://github.com/user-attachments/assets/dd9fd1d6-5c67-47c8-a40e-1029c554dd44) |

